### PR TITLE
add camera plate scaling for V4

### DIFF
--- a/DetectorGeometry/EVN_V4_Oct2012_oldArrayConfig_20130428_v420.txt
+++ b/DetectorGeometry/EVN_V4_Oct2012_oldArrayConfig_20130428_v420.txt
@@ -2192,6 +2192,11 @@ Camera rotation (counterclockwise) in [deg]
 * CAROT 3 0.
 * CAROT 4 0.
 
+* CAMPLATE 1 0.965 0. 0.
+* CAMPLATE 2 0.965 0. 0.
+* CAMPLATE 3 0.965 0. 0.
+* CAMPLATE 4 0.965 0. 0.
+
 
 Phototubes (PMPIX). For each we have 
    -the telescope identification number


### PR DESCRIPTION
Add missing camera scaling for V4 data. Follows from DC optics and based on ray-tracing work by Steve F.